### PR TITLE
Update to work with APFS filesystem.

### DIFF
--- a/DiskFiller.xcodeproj/project.pbxproj
+++ b/DiskFiller.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 				TargetAttributes = {
 					63361EBF1EC48C2F009CCA90 = {
 						CreatedOnToolsVersion = 8.3.2;
+						DevelopmentTeam = GZS3K47B3Y;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -120,6 +121,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -282,13 +284,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = GZS3K47B3Y;
 				INFOPLIST_FILE = DiskFiller/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = co.fieldapps.DiskFiller;
+				PRODUCT_BUNDLE_IDENTIFIER = com.serpentisei.DiskFiller;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -296,13 +298,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = GZS3K47B3Y;
 				INFOPLIST_FILE = DiskFiller/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = co.fieldapps.DiskFiller;
+				PRODUCT_BUNDLE_IDENTIFIER = com.serpentisei.DiskFiller;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/DiskFiller/AppDelegate.swift
+++ b/DiskFiller/AppDelegate.swift
@@ -6,7 +6,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         return true
     }
 

--- a/DiskFiller/FileHandler.swift
+++ b/DiskFiller/FileHandler.swift
@@ -26,6 +26,7 @@ final class FileHandler {
         }
         fileHandlingQueue.async {
             do {
+                let imageData = try Data(contentsOf: URL(fileURLWithPath: sourcePath))
                 let filePaths = try self.fileManager.contentsOfDirectory(atPath: documentsPath)
                 var i = filePaths.count
                 self.numberOfFilesStored = i
@@ -35,7 +36,7 @@ final class FileHandler {
                     let filePath = documentsPath.appending(fileName)
                     if !self.fileManager.fileExists(atPath: filePath) {
                         do {
-                            try self.fileManager.copyItem(atPath: sourcePath, toPath: filePath)
+                            try imageData.write(to: URL(fileURLWithPath: filePath))
                             self.delegate?.fileHandlerDidAddFile(fileHander: self)
                             self.incrementFilesStored()
                         } catch {


### PR DESCRIPTION
As of iOS 10.3 this utility no longer worked as intended, since APFS won't actually write the new data to disk until the file has been modified. If we give it the raw bytes to write, it can't make this optimization.